### PR TITLE
fix #27: stabilize eSTK slot switching

### DIFF
--- a/lib/adapter/omapi/omapi_adapter.dart
+++ b/lib/adapter/omapi/omapi_adapter.dart
@@ -226,11 +226,22 @@ class OmapiAdapter extends BaseAdapter {
       final readerId = _internalReaderName ?? "default";
 
       // 1. Check for same AID re-use
+      // For eSTK slots, only reuse the first AID requested by the caller.
       if (aids != null && aids.isNotEmpty) {
         log.info(
           'Checking for re-use. Targets: $aids. Current mappings: $_channelMappings',
         );
-        for (final aid in aids) {
+        const estkSlotAids = {
+          'A06573746B6D65FFFF4953442D522030',
+          'A06573746B6D65FFFF4953442D522031',
+        };
+        final preferredAid = aids.first;
+        final isEstkSlotAid = estkSlotAids.contains(
+          preferredAid.toUpperCase(),
+        );
+        final reuseCandidates = isEstkSlotAid ? [preferredAid] : aids;
+
+        for (final aid in reuseCandidates) {
           final existingId = _channelMappings.entries
               .firstWhereOrNull(
                 (e) => e.value.toUpperCase() == aid.toUpperCase(),


### PR DESCRIPTION
## Summary

Fix unstable eSTK.me SE0/SE1 slot switching on Android OMAPI.(Fix #27 )

This PR fixes an issue where the slot-switching UI could show “switched” even though the app was still connected to the old eSTK.me slot. It also makes the app remember the last successfully selected eSTK.me slot.

## Background

On my Android device, after restarting the app, it sometimes opened the eSTK.me card on SE1. When switching back to SE0 from the UI, the app could show a successful switch message, but the actual OMAPI logical channel was still connected to SE1.

The key failure pattern from the logs was:

```text
2026-07-05 10:09:12.487175 [ProfileManager] INFO: Prioritizing cached working AID for Reader{id: omapi:SIM2, name: SIM 2, source: mRa}: A06573746B6D65FFFF4953442D522030

2026-07-05 10:09:12.487299 [OmapiAdapter] INFO: Checking for re-use. Targets: [a06573746b6d65ffff4953442d522030, a06573746b6d65ffff4953442d522031, a0000005591010ffffffff8900000100, a0000005591010ffffffff8900050500, a0000005591010000000008900000300, a0000005591010ffffffff8900000177]. Current mappings: {1: a06573746b6d65ffff4953442d522031}

2026-07-05 10:09:12.487356 [OmapiAdapter] INFO: Reusing existing logical channel 1 for AID a06573746b6d65ffff4953442d522031 (refs: 1)

2026-07-05 10:09:12.487392 [ProfileManager] INFO: Channel opened with AID: a06573746b6d65ffff4953442d522031

2026-07-05 10:09:12.500530 [EstkPlugin] INFO: Opened ESTK channel: A06573746B6D65FFFF4953442D522031 for EID: <redacted>
```

In this case, the app had already requested SE0 first:

```text
A06573746B6D65FFFF4953442D522030
```

But OMAPI still had an old SE1 logical channel cached:

```text
a06573746b6d65ffff4953442d522031
```

The previous reuse logic scanned the whole AID list and reused any existing channel whose AID appeared anywhere in the list. Since SE1 was still present as a fallback candidate, the old SE1 channel was reused before SE0 was actually opened.

So this was not only a UI issue. The app could request SE0, but still continue talking to SE1 because a stale OMAPI logical channel was reused.

## Main Changes

Fix SE0/SE1 slot switching failure, the scope of modification is limited to the eSTK module.

## Expected Behavior

When pressing the SE0/SE1 switch button, switching between SE0 and SE1 works normally.

## Testing

Tested on my Android phone with an eSTK.me plus+ card inserted.

The original issue, where switching back to SE0 could still leave the app connected to SE1 while showing a success message, is fixed.
