### PR TITLE
feat: remember last selected eSTK slot

### DIFF
--- a/lib/logic/profile_manager.dart
+++ b/lib/logic/profile_manager.dart
@@ -154,8 +154,8 @@ class ProfileManager {
       ]);
     }
 
-    // Prioritize working AID for this reader (Ephemeral, tied to ATR)
     final readerName = adapter.connectedReader;
+    // Prioritize the persisted AID when a saved eSTKme preference is found.(Persistent, tied to ATR)
     if (readerName != null) {
       final persistedAid = currentAtr.isEmpty
           ? null
@@ -165,11 +165,12 @@ class ProfileManager {
         aids.removeWhere((aid) => listEquals(aid, persistedBytes));
         aids.insert(0, persistedBytes.toList());
         _log.info(
-          "Prioritizing persisted eSTK AID for $readerName: $persistedAid",
+          "Prioritizing persisted eSTKme AID for $readerName: $persistedAid",
         );
       }
     }
 
+    // Prioritize working AID for this reader (Ephemeral, tied to ATR)
     if (readerName != null) {
       final cached = _workingAidCache[readerName.id];
       final currentAtr = adapter.lastAtr;

--- a/lib/logic/profile_manager.dart
+++ b/lib/logic/profile_manager.dart
@@ -157,6 +157,20 @@ class ProfileManager {
     // Prioritize working AID for this reader (Ephemeral, tied to ATR)
     final readerName = adapter.connectedReader;
     if (readerName != null) {
+      final persistedAid = currentAtr.isEmpty
+          ? null
+          : AppSettings().getPreferredEstkAid(readerName.id, currentAtr)?.toUpperCase();
+      if (persistedAid != null) {
+        final persistedBytes = HexUtils.hexToBytes(persistedAid);
+        aids.removeWhere((aid) => listEquals(aid, persistedBytes));
+        aids.insert(0, persistedBytes.toList());
+        _log.info(
+          "Prioritizing persisted eSTK AID for $readerName: $persistedAid",
+        );
+      }
+    }
+
+    if (readerName != null) {
       final cached = _workingAidCache[readerName.id];
       final currentAtr = adapter.lastAtr;
 

--- a/lib/pages/profiles_screen.dart
+++ b/lib/pages/profiles_screen.dart
@@ -1104,7 +1104,7 @@ class _ProfilesScreenState extends State<ProfilesScreen>
       final atr = _adapter.lastAtr;
       if (activeAid == targetAid && atr != null && atr.isNotEmpty) {
         await AppSettings().setPreferredEstkAid(reader.id, atr, targetAid);
-        _log.info("Persisted eSTK slot for ${reader.id}: $targetAid");
+        _log.info("Persisted eSTKme slot for ${reader.id}: $targetAid");
       }
 
       if (mounted) {

--- a/lib/pages/profiles_screen.dart
+++ b/lib/pages/profiles_screen.dart
@@ -1100,6 +1100,13 @@ class _ProfilesScreenState extends State<ProfilesScreen>
       await Future.delayed(const Duration(milliseconds: 300));
       await _listProfiles();
 
+      final activeAid = _adapter.connectedReader?.aid?.toUpperCase();
+      final atr = _adapter.lastAtr;
+      if (activeAid == targetAid && atr != null && atr.isNotEmpty) {
+        await AppSettings().setPreferredEstkAid(reader.id, atr, targetAid);
+        _log.info("Persisted eSTK slot for ${reader.id}: $targetAid");
+      }
+
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(

--- a/lib/settings/app_settings.dart
+++ b/lib/settings/app_settings.dart
@@ -643,6 +643,23 @@ class AppSettings extends ChangeNotifier {
     notifyListeners();
   }
 
+  String? getPreferredEstkAid(String readerId, String atr) {
+    final key =
+        'preferredEstkAid_v1_${readerId.toLowerCase()}|${atr.toUpperCase()}';
+    return _prefs?.getString(key);
+  }
+
+  Future<void> setPreferredEstkAid(
+    String readerId,
+    String atr,
+    String aid,
+  ) async {
+    final key =
+        'preferredEstkAid_v1_${readerId.toLowerCase()}|${atr.toUpperCase()}';
+    await _prefs?.setString(key, aid);
+    notifyListeners();
+  }
+
   String? getPersistedEid(String readerId) {
     final key = readerId.toLowerCase();
     final jsonStr = _prefs?.getString('persisted_reader_eids_v2');


### PR DESCRIPTION
NekokoLPA2 currently cannot remember the last active slot for users with multi-slot eSTKme hardware.
For users who only use SE0 (slot 1), they have to manually switch to their target slot every time the app launches.
Therefore, I introduced this feature to improve the user experience for multi-slot eSTKme users.
